### PR TITLE
Better Tabzilla alignment with the top border of the page

### DIFF
--- a/Hax/style.css
+++ b/Hax/style.css
@@ -40,7 +40,7 @@ a:hover {
 
 #tabzilla {
   position: absolute;
-  top: 0;
+  top: 4px;
   right: 32px;
   display: none;
 }


### PR DESCRIPTION
Just a visual refinement. IMO this way tabzilla looks better and more aligned with the good ol' top page border.
i.e.:
![tabzilla_no_space_before](https://cloud.githubusercontent.com/assets/1832078/9674598/640b5336-52aa-11e5-835c-4351319f0913.png)
![tabzilla_space_before](https://cloud.githubusercontent.com/assets/1832078/9674599/640ec6e2-52aa-11e5-8aeb-e0db7a648e5b.png)

What do you think?
