### PR TITLE
Bug 1282561 - remove URL from comments

### DIFF
--- a/Hax/comments.php
+++ b/Hax/comments.php
@@ -47,10 +47,6 @@
           <label for="email"><?php _e('Your e-mail', 'mozhacks'); ?> <?php if ($req) :?><abbr title="<?php _e('(required)', 'onemozilla'); ?>">*</abbr><?php endif; ?></label>
           <input type="email" name="email" id="email" size="25" <?php if ($req) echo "required aria-required='true'"; ?>>
         </div>
-        <div class="field" id="cmt-web">
-          <label for="url"><?php _e('Your website', 'mozhacks'); ?></label>
-          <input type="url" name="url" id="url" size="25">
-        </div>
         <div id="cmt-ackbar">
           <label for="age"><?php _e('Spam robots, please fill in this field. Humans should leave it blank.', 'mozhacks'); ?></label>
           <input type="text" name="age" id="age" size="4" tabindex="-1">

--- a/Hax/functions.php
+++ b/Hax/functions.php
@@ -307,17 +307,9 @@ function hacks_comment($comment, $args, $depth) {
   <?php if ( $comment_type == 'trackback' ) : ?>
   <?php elseif ( $comment_type == 'pingback' ) : ?>
   <?php else : ?>
-    <?php if ( ( $comment->comment_author_url != "http://" ) && ( $comment->comment_author_url != "" ) ) : // if author has a link ?>
-     <b class="comment__title">
-       <a href="<?php comment_author_url(); ?>" class="url" rel="nofollow external" title="<?php comment_author_url(); ?>">
-         <cite class="author fn"><?php comment_author(); ?></cite>
-       </a>
-     </b>
-    <?php else : // author has no link ?>
-      <b class="comment__title vcard">
-        <cite class="author fn"><?php comment_author(); ?></cite>
-      </b>
-    <?php endif; ?>
+    <b class="comment__title vcard">
+      <cite class="author fn"><?php comment_author(); ?></cite>
+    </b>
   <?php endif; ?>
 
     <?php if ($comment->comment_approved == '0') : ?>


### PR DESCRIPTION
To help curb spam, this removes the URL field from the comment form and the link from comment display. https://bugzilla.mozilla.org/show_bug.cgi?id=1282561
