### PR TITLE
Add .pullquote style

### DIFF
--- a/Hax/css/screen.css
+++ b/Hax/css/screen.css
@@ -76,6 +76,28 @@ input {
   line-height: normal;
 }
 
+.pullquote {
+  font-size: 1.1rem;
+  background: #eee;
+  border-left: 5px solid #ccc;
+  margin: 2rem 1rem;
+  padding: 1rem;
+  quotes: "\201C""\201D""\2018""\2019";
+}
+
+.pullquote:before {
+  color: #ccc;
+  content: open-quote;
+  font-size: 3.8rem;
+  line-height: 0.1rem;
+  margin-right: 0.10rem;
+  vertical-align: -1.5rem;
+}
+
+.pullquote p {
+  display: inline;
+}
+
 hr.dino {
   margin: 2em auto;
   width: 20em;
@@ -760,6 +782,10 @@ td, th {
 
   .branding h1 {
     text-align: left;
+  }
+
+  .pullquote {
+    max-width: 58ch;
   }
 
   .post p,


### PR DESCRIPTION
Based on the [CSS-Tricks example](https://css-tricks.com/snippets/css/simple-and-nice-blockquote-styling/), with a nod to existing unit conventions, `pre` and `code` block styles, and media queries. Local environment tests LGTM on...
- IE11 (Win7)
- Fx Android, Fx Desktop (beta, OSX)
- Chrome (OSX, Android Nougat)
- Safari (OSX)
- Opera (OSX)
