### PR TITLE
Close quotes to avoid alternate quote marks.

### DIFF
--- a/Hax/css/screen.css
+++ b/Hax/css/screen.css
@@ -94,6 +94,10 @@ input {
   vertical-align: -1.5rem;
 }
 
+.pullquote:after {
+  content: no-close-quote;
+}
+
 .pullquote p {
   display: inline;
 }


### PR DESCRIPTION
Quote marks alternate from " to ', unless you close them. This is good behavior, so I'm just closing them here.
