### PR TITLE
Fix display of local avatars

### DIFF
--- a/Hax/single.php
+++ b/Hax/single.php
@@ -15,12 +15,12 @@ $featured_id = get_cat_ID('Featured Article');
   <h1 class="post__title"><?php the_title(); ?></h1>
   <div class="byline">
     <h3 class="post__author">
-      <?php if (function_exists(coauthors)) : ?>
+      <?php if (function_exists('coauthors')) : ?>
         <?php
           $authors = get_coauthors($post->ID);
           $authorPos = 0;
         ?>
-        <?php echo get_avatar($authors[0], 64) ?>
+        <?php echo get_avatar($authors[0]->user_email, 64); ?>
         By
         <?php foreach ($authors as $author) : ?>
           <?php $authorPos++; ?>
@@ -76,7 +76,7 @@ $featured_id = get_cat_ID('Featured Article');
   <article class="post" role="article">
     <?php the_content(); ?>
     <section class="about">
-      <?php if (function_exists(coauthors)) : ?>
+      <?php if (function_exists('coauthors')) : ?>
         <?php $authors = get_coauthors($post->ID); ?>
         <?php foreach ($authors as $author) : ?>
           <h2 class="about__header">About
@@ -85,9 +85,7 @@ $featured_id = get_cat_ID('Featured Article');
                 <?php echo hacks_author($author->display_name); ?>
               </a>
             <?php else : ?>
-              <a class="url" href="<?php echo get_author_posts_url($author->ID); ?>">
-                <?php echo hacks_author($author->display_name); ?>
-              </a>
+              <?php echo hacks_author($author->display_name); ?>
             <?php endif; ?>
           </h3>
           <?php if ($author->description) : ?>

--- a/Hax/views/article-list.php
+++ b/Hax/views/article-list.php
@@ -1,6 +1,12 @@
 <li class="list-item row listing">
-  <?php $authors = get_coauthors($post->ID); ?>
-  <?php echo get_avatar($authors[0], 72) ?>
+<?php
+  if (function_exists('coauthors')) :
+    $authors = get_coauthors($post->ID);
+    echo get_avatar($authors[0]->user_email, 72);
+  else :
+    echo get_avatar(get_the_author_meta('user_email'), 72);
+  endif;
+?>
   <div class="block block--1">
     <h3 class="post__title">
       <a href="<?php the_permalink() ?>"><?php the_title(); ?></a>


### PR DESCRIPTION
It seems the Simple Local Avatars plugin expects a `user_email` as the author's identifier in order to intervene and replace the remote Gravatar with the local image, but the email wasn't being passed specifically to the `get_avatar` function. WordPress was able to parse out the email to render a Gravatar but the plugin couldn't find it to match. 

If the local avatars plugin is disabled it falls back to the default avatar.

I also added a basic check for co-authors in the list view, to prevent throwing an error if Co-Authors Plus is disabled.