### PR TITLE
Check if $loop_orderby is set

### DIFF
--- a/Hax/functions.php
+++ b/Hax/functions.php
@@ -971,7 +971,7 @@ function fc_custom_loop($args) {
        If 'post__in' is in args and 'orderby' is set to 'none', just grab those posts,
        in the order provided in the 'post__in' array.
     */
-    if($loop_orderby && $loop_orderby == 'none' && $loop_post__in)
+    if(isset($loop_orderby) && $loop_orderby == 'none' && $loop_post__in)
     {
         foreach($loop_post__in as $post_id)
             $loop_posts[] = get_post($post_id);


### PR DESCRIPTION
In [functions.php line 974](https://github.com/potch/hax/blob/master/Hax/functions.php#L974 ), the `if` statement that checks for the truthiness of `$loop_orderby` should use [isset](https://www.php.net/manual/en/function.isset.php). Without this, an error appears in debug mode:
<img width="709" alt="loop_orderby_error" src="https://user-images.githubusercontent.com/4011193/228386038-ed54ba93-1daa-4500-bf0e-cd437fa6bf5f.png">

Using `isset` is the less error-inducing way of checking if a variable is defined.